### PR TITLE
Use brew --prefix to add lib/ and include/ paths that should have argp

### DIFF
--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -12,7 +12,22 @@ endif()
 
 # OSX
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  # argparse (homebrew/argp-standalone)
+  # Get homebrew's path prefix
+  execute_process(
+    COMMAND brew --prefix
+    RESULT_VARIABLE brew_result
+    OUTPUT_VARIABLE brew_prefix
+  )
+
+  # Kill the build early if homebrew isn't installed
+  if(NOT "${brew_result}" STREQUAL "0")
+    message(FATAL_ERROR "`brew --prefix` failed with ${brew_result} - is homebrew installed?")
+  endif()
+
+  # Add homebrew's include and lib directories to access argp
+  string(STRIP ${brew_prefix} brew_prefix)
+  include_directories(${brew_prefix}/include/)
+  link_directories(${brew_prefix}/lib/)
   set(SPLATT_LIBS ${SPLATT_LIBS} argp)
 endif()
 


### PR DESCRIPTION
I needed to add these so the compiler and linker could find `argp.h` and `libargp.a`, respectively. Merging directly into your `osx-argp` branch since it's not merged with `master` yet.