### PR TITLE
changed TILE_DEPTH to TILE_LEVEL and added ntiled_modes to CSF

### DIFF
--- a/include/splatt/structs.h
+++ b/include/splatt/structs.h
@@ -94,6 +94,10 @@ typedef struct splatt_csf
   /** @brief How many tiles there are. */
   splatt_idx_t ntiles;
 
+  /** @brief How many modes of the tensor (i.e., CSF levels) are tiled. Counted
+   *         from the leaf (bottom) mode. */
+  splatt_idx_t ntiled_modes;
+
   /** @brief For a dense tiling, how many tiles along each mode. */
   splatt_idx_t tile_dims[SPLATT_MAX_NMODES];
 

--- a/include/splatt/types_config.h
+++ b/include/splatt/types_config.h
@@ -100,7 +100,7 @@ typedef enum
   SPLATT_OPTION_RANDSEED,   /* Random number seed */
   SPLATT_OPTION_CSF_ALLOC,  /* How many (and which) tensors to allocate. */
   SPLATT_OPTION_TILE,       /* Use cache tiling during MTTKRP. */
-  SPLATT_OPTION_TILEDEPTH,  /* Minimium depth in CSF to tile, 0-indexed. */
+  SPLATT_OPTION_TILELEVEL,  /* How many levels of the CSF are tiled? */
 
   SPLATT_OPTION_DECOMP,     /* Decomposition to use on distributed systems */
   SPLATT_OPTION_COMM,       /* Communication pattern to use */

--- a/src/csf.c
+++ b/src/csf.c
@@ -368,6 +368,7 @@ static void p_csf_alloc_untiled(
   tt_sort(tt, ct->dim_perm[0], ct->dim_perm);
 
   ct->ntiles = 1;
+  ct->ntiled_modes = 0;
   for(idx_t m=0; m < nmodes; ++m) {
     ct->tile_dims[m] = 1;
   }
@@ -411,14 +412,22 @@ static void p_csf_alloc_densetile(
 {
   idx_t const nmodes = tt->nmodes;
 
+  /* how many levels we tile (counting from the bottom) */
+  ct->ntiled_modes = (idx_t)splatt_opts[SPLATT_OPTION_TILELEVEL];
+  ct->ntiled_modes = SS_MIN(ct->ntiled_modes, ct->nmodes);
+
+  /* how many levels from the root do we start tiling? */
+  idx_t const tile_depth = ct->nmodes - ct->ntiled_modes;
+
   idx_t ntiles = 1;
-  for(idx_t m=0; m < ct->nmodes; ++m) {
+  for(idx_t m=0; m < nmodes; ++m) {
     idx_t const depth = csf_mode_depth(m, ct->dim_perm, ct->nmodes);
-    if(depth >= splatt_opts[SPLATT_OPTION_TILEDEPTH]) {
+    if(depth >= tile_depth) {
       ct->tile_dims[m] = (idx_t) splatt_opts[SPLATT_OPTION_NTHREADS];
     } else {
       ct->tile_dims[m] = 1;
     }
+
     ntiles *= ct->tile_dims[m];
   }
 

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -1070,7 +1070,7 @@ static void p_root_decide(
       break;
     case SPLATT_DENSETILE:
       /* this mode may not be tiled due to minimum tiling depth */
-      if(opts[SPLATT_OPTION_TILEDEPTH] > 0) {
+      if(tensor->ntiled_modes < tensor->nmodes) {
         for(idx_t t=0; t < tensor->ntiles; ++t) {
           p_csf_mttkrp_root(tensor, t, mats, thds);
           #pragma omp barrier
@@ -1122,7 +1122,7 @@ static void p_leaf_decide(
       break;
     case SPLATT_DENSETILE:
       /* this mode may not be tiled due to minimum tiling depth */
-      if(opts[SPLATT_OPTION_TILEDEPTH] > depth) {
+      if(tensor->ntiled_modes == 0) {
         for(idx_t t=0; t < tensor->ntiles; ++t) {
           p_csf_mttkrp_leaf(tensor, 0, mats, thds);
         }
@@ -1171,7 +1171,7 @@ static void p_intl_decide(
       break;
     case SPLATT_DENSETILE:
       /* this mode may not be tiled due to minimum tiling depth */
-      if(opts[SPLATT_OPTION_TILEDEPTH] > depth) {
+      if(tensor->tile_dims[mode] == 1) {
         for(idx_t t=0; t < tensor->ntiles; ++t) {
           p_csf_mttkrp_internal(tensor, t, mats, mode, thds);
         }

--- a/src/opts.c
+++ b/src/opts.c
@@ -22,7 +22,9 @@ double * splatt_default_opts(void)
 
   opts[SPLATT_OPTION_CSF_ALLOC] = SPLATT_CSF_TWOMODE;
   opts[SPLATT_OPTION_TILE]      = SPLATT_NOTILE;
-  opts[SPLATT_OPTION_TILEDEPTH] = 1;
+
+  /* Tile one level by default. */
+  opts[SPLATT_OPTION_TILELEVEL] = 1;
 
   opts[SPLATT_OPTION_DECOMP] = SPLATT_DECOMP_MEDIUM;
   opts[SPLATT_OPTION_COMM]   = SPLATT_COMM_ALL2ALL;

--- a/src/stats.c
+++ b/src/stats.c
@@ -273,8 +273,8 @@ void cpd_stats(
     printf("NO");
     break;
   case SPLATT_DENSETILE:
-    printf("DENSE TILE-DEPTH=%"SPLATT_PF_IDX,
-        (idx_t)opts[SPLATT_OPTION_TILEDEPTH]);
+    printf("DENSE TILED-MODES=%"SPLATT_PF_IDX,
+        (idx_t)opts[SPLATT_OPTION_TILELEVEL]);
     break;
   case SPLATT_SYNCTILE:
     printf("SYNC");
@@ -359,7 +359,7 @@ void mpi_cpd_stats(
     printf("NO");
     break;
   case SPLATT_DENSETILE:
-    printf("DENSE TILE-DEPTH=%"SPLATT_PF_IDX,
+    printf("DENSE TILED-MODES=%"SPLATT_PF_IDX,
         (idx_t)opts[SPLATT_OPTION_TILEDEPTH]);
     break;
   case SPLATT_SYNCTILE:

--- a/tests/csf_test.c
+++ b/tests/csf_test.c
@@ -193,12 +193,11 @@ CTEST2(csf_one_init, dense_tiled_normsq)
   data->opts[SPLATT_OPTION_NTHREADS] = 7;
 
   for(idx_t m=0; m < data->tt->nmodes; ++m) {
-    data->opts[SPLATT_OPTION_TILEDEPTH] = m;
+    data->opts[SPLATT_OPTION_TILELEVEL] = m;
     splatt_csf * csf = csf_alloc(data->tt, data->opts);
     val_t mynorm = csf_frobsq(csf);
     csf_free(csf, data->opts);
 
     ASSERT_DBL_NEAR_TOL(gold_norm, mynorm, 1e-5);
   }
-
 }

--- a/tests/mttkrp_test.c
+++ b/tests/mttkrp_test.c
@@ -44,6 +44,12 @@ static void p_csf_mttkrp(
   idx_t const nthreads = opts[SPLATT_OPTION_NTHREADS];
   for(idx_t i=0; i < ntensors; ++i) {
     sptensor_t * const tt = tensors[i];
+
+    /* skip tensors with more tiles than modes (which are ignored) */
+    if((idx_t)opts[SPLATT_OPTION_TILELEVEL] > tt->nmodes) {
+      continue;
+    }
+
     splatt_csf * cs = splatt_csf_alloc(tt, opts);
 
     /* add 64 bytes to avoid false sharing */
@@ -165,26 +171,12 @@ CTEST2(mttkrp, csf_all_notile)
   opts[SPLATT_OPTION_NTHREADS]   = 7;
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ALLMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_NOTILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
+  opts[SPLATT_OPTION_TILELEVEL]  = 0;
 
   p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
       data->nfactors);
 }
 
-
-CTEST2(mttkrp, csf_all_densetile)
-{
-  idx_t const nthreads = 7;
-
-  double * opts = splatt_default_opts();
-  opts[SPLATT_OPTION_NTHREADS]   = 7;
-  opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ALLMODE;
-  opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
-
-  p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
-      data->nfactors);
-}
 
 
 CTEST2(mttkrp, csf_all_densetile_alldepth)
@@ -196,8 +188,8 @@ CTEST2(mttkrp, csf_all_densetile_alldepth)
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ALLMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
 
-  for(splatt_idx_t i=1; i <= SPLATT_MAX_NMODES; ++i) {
-    opts[SPLATT_OPTION_TILEDEPTH]  = i;
+  for(splatt_idx_t i=0; i <= SPLATT_MAX_NMODES; ++i) {
+    opts[SPLATT_OPTION_TILELEVEL]  = i;
     p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
         data->nfactors);
   }
@@ -213,24 +205,12 @@ CTEST2(mttkrp, csf_one_notile)
   opts[SPLATT_OPTION_NTHREADS]   = 7;
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ONEMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_NOTILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
+  opts[SPLATT_OPTION_TILELEVEL]  = 0;
 
   p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
       data->nfactors);
 }
 
-
-CTEST2(mttkrp, csf_one_densetile)
-{
-  double * opts = splatt_default_opts();
-  opts[SPLATT_OPTION_NTHREADS]   = 7;
-  opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ONEMODE;
-  opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
-
-  p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
-      data->nfactors);
-}
 
 
 CTEST2(mttkrp, csf_one_densetile_alldepth)
@@ -240,8 +220,8 @@ CTEST2(mttkrp, csf_one_densetile_alldepth)
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_ONEMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
 
-  for(splatt_idx_t i=1; i <= SPLATT_MAX_NMODES; ++i) {
-    opts[SPLATT_OPTION_TILEDEPTH]  = i;
+  for(splatt_idx_t i=0; i <= SPLATT_MAX_NMODES; ++i) {
+    opts[SPLATT_OPTION_TILELEVEL]  = i;
     p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
         data->nfactors);
   }
@@ -256,25 +236,11 @@ CTEST2(mttkrp, csf_two_notile)
   opts[SPLATT_OPTION_NTHREADS]   = 7;
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_TWOMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_NOTILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
+  opts[SPLATT_OPTION_TILELEVEL]  = 0;
 
   p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
       data->nfactors);
 }
-
-
-CTEST2(mttkrp, csf_two_densetile)
-{
-  double * opts = splatt_default_opts();
-  opts[SPLATT_OPTION_NTHREADS]   = 7;
-  opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_TWOMODE;
-  opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
-  opts[SPLATT_OPTION_TILEDEPTH]  = 0;
-
-  p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
-      data->nfactors);
-}
-
 
 CTEST2(mttkrp, csf_two_densetile_alldepth)
 {
@@ -283,8 +249,8 @@ CTEST2(mttkrp, csf_two_densetile_alldepth)
   opts[SPLATT_OPTION_CSF_ALLOC]  = SPLATT_CSF_TWOMODE;
   opts[SPLATT_OPTION_TILE]       = SPLATT_DENSETILE;
 
-  for(splatt_idx_t i=1; i <= SPLATT_MAX_NMODES; ++i) {
-    opts[SPLATT_OPTION_TILEDEPTH]  = i;
+  for(splatt_idx_t i=0; i <= SPLATT_MAX_NMODES; ++i) {
+    opts[SPLATT_OPTION_TILELEVEL]  = i;
     p_csf_mttkrp(opts, data->tensors, data->ntensors, data->mats, data->gold,
         data->nfactors);
   }


### PR DESCRIPTION
`SPLATT_OPTION_TILEDEPTH` is easier to code in some places, but complicates things for
users. Instead, `SPLATT_OPTION_TILELEVEL` specifies just how many modes to tile (always starting from the leaves).

This additionally adds a `ntiled_modes` field to the CSF struct. It's easier and much safer to work with
than looking at a `splatt_opts` array.