### PR TITLE
csf_{depth,mode}_to_{mode,depth}() now used throughout.

### DIFF
--- a/include/splatt/structs.h
+++ b/include/splatt/structs.h
@@ -84,9 +84,17 @@ typedef struct splatt_csf
   /** @brief The dimension of each mode. */
   splatt_idx_t dims[SPLATT_MAX_NMODES];
 
-  /** @brief The permutation of the tensor modes.
-   *         dim_perm[0] is the mode stored at the root level and so on. */
+  /** @brief This maps levels in the tensor to actual tensor modes.
+   *         dim_perm[0] is the mode stored at the root level and so on.
+   *         NOTE: do not use directly; use`csf_depth_to_mode()` instead.
+   */
   splatt_idx_t dim_perm[SPLATT_MAX_NMODES];
+
+  /**
+   * @brief Inverse of dim_perm. This maps tensor modes to levels in the CSF.
+   *        NOTE: do not use directly; use`csf_mode_to_depth()` instead.
+   */
+  splatt_idx_t dim_iperm[SPLATT_MAX_NMODES];
 
   /** @brief Which tiling scheme this tensor is stored as. */
   splatt_tile_type which_tile;

--- a/src/csf.h
+++ b/src/csf.h
@@ -80,6 +80,7 @@ void csf_free(
   double const * const opts);
 
 
+#define csf_free_mode splatt_csf_free_mode
 /**
 * @brief Free the memory allocated for one CSF representation. This should be
 *        paired with csf_alloc_mode().
@@ -88,6 +89,7 @@ void csf_free(
 */
 void csf_free_mode(
     splatt_csf * const csf);
+
 
 #define csf_storage splatt_csf_storage
 /**
@@ -136,31 +138,44 @@ void csf_find_mode_order(
   idx_t * const perm_dims);
 
 
-#define csf_mode_depth splatt_csf_mode_depth
+#define csf_mode_to_depth splatt_csf_mode_to_depth
 /**
 * @brief Map a mode (in the input system) to the tree level that it is found.
 *        This is equivalent to the inverse dim_perm.
 *
+* @param csf The CSF tensor.
 * @param mode The mode (relative to the input) to lookup.
-* @param perm The dimenison permutation.
-* @param nmodes The number of modes.
 *
 * @return The level of the tree that mode is mapped to.
 */
-static inline idx_t csf_mode_depth(
-  idx_t const mode,
-  idx_t const * const perm,
-  idx_t const nmodes)
+static inline idx_t csf_mode_to_depth(
+    splatt_csf const * const csf,
+    idx_t const mode)
 {
-  for(idx_t m=0; m < nmodes; ++m) {
-    if(perm[m] == mode) {
-      return m;
-    }
-  }
-
-  /* XXX: ERROR */
-  assert(1 == 2);
-  return MAX_NMODES;
+  assert(mode < csf->nmodes);
+  return csf->dim_iperm[mode];
 }
+
+
+
+#define csf_depth_to_mode splatt_csf_depth_to_mode
+/**
+* @brief Map a level in the CSF tree (zero-indexed, measured from root) to the
+*        actual mode in the tensor, respecting any mode permutation.
+*
+* @param csf The CSF tensor.
+* @param level The level in the tree.
+*
+* @return The actual mode in the tensor.
+*/
+static inline idx_t csf_depth_to_mode(
+    splatt_csf const * const csf,
+    idx_t const level)
+{
+  assert(level < csf->nmodes);
+  return csf->dim_perm[level];
+}
+
+
 
 #endif

--- a/src/graph.c
+++ b/src/graph.c
@@ -184,7 +184,7 @@ static adj_t p_count_adj_size(
 
 /**
 * @brief Compute the offset of a certain CSF tree depth (when all indices are
-*        mapped to vertices). This accounts for csf->dim_perm.
+*        mapped to vertices). This accounts for CSF mode permutation.
 *
 *        For example, with no permutation and depth=2, this returns
 *        csf->dims[0] + csf->dims[1].
@@ -198,7 +198,7 @@ static idx_t p_calc_offset(
     splatt_csf const * const csf,
     idx_t const depth)
 {
-  idx_t const mode = csf->dim_perm[depth];
+  idx_t const mode = csf_depth_to_mode(csf, depth);
   idx_t offset = 0;
   for(idx_t m=0; m < mode; ++m) {
     offset += csf->dims[m];

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -248,8 +248,8 @@ static void p_csf_mttkrp_root_tiled3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[1]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[2]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 1)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 2)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -307,8 +307,8 @@ static void p_csf_mttkrp_root3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[1]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[2]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 1)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 2)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -367,8 +367,8 @@ static void p_csf_mttkrp_internal3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[0]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[2]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 0)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 2)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -430,8 +430,8 @@ static void p_csf_mttkrp_leaf3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[0]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[1]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 0)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 1)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -501,7 +501,7 @@ static void p_csf_mttkrp_root_tiled(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
     memset(buf[m], 0, nfactors * sizeof(val_t));
@@ -562,7 +562,7 @@ static void p_csf_mttkrp_root(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
     memset(buf[m], 0, nfactors * sizeof(val_t));
@@ -607,8 +607,8 @@ static void p_csf_mttkrp_leaf_tiled3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[0]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[1]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 0)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 1)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -676,7 +676,7 @@ static void p_csf_mttkrp_leaf_tiled(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
   }
@@ -758,7 +758,7 @@ static void p_csf_mttkrp_leaf(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
   }
@@ -826,8 +826,8 @@ static void p_csf_mttkrp_internal_tiled3(
   idx_t const * const restrict fids = ct->pt[tile_id].fids[1];
   idx_t const * const restrict inds = ct->pt[tile_id].fids[2];
 
-  val_t const * const avals = mats[ct->dim_perm[0]]->vals;
-  val_t const * const bvals = mats[ct->dim_perm[2]]->vals;
+  val_t const * const avals = mats[csf_depth_to_mode(ct, 0)]->vals;
+  val_t const * const bvals = mats[csf_depth_to_mode(ct, 2)]->vals;
   val_t * const ovals = mats[MAX_NMODES]->vals;
   idx_t const nfactors = mats[MAX_NMODES]->J;
 
@@ -897,7 +897,7 @@ static void p_csf_mttkrp_internal_tiled(
   idx_t const nfactors = mats[0]->J;
 
   /* find out which level in the tree this is */
-  idx_t outdepth = csf_mode_depth(mode, ct->dim_perm, nmodes);
+  idx_t const outdepth = csf_mode_to_depth(ct, mode);
 
   val_t * mvals[MAX_NMODES];
   val_t * buf[MAX_NMODES];
@@ -905,7 +905,7 @@ static void p_csf_mttkrp_internal_tiled(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
     memset(buf[m], 0, nfactors * sizeof(val_t));
@@ -985,7 +985,7 @@ static void p_csf_mttkrp_internal(
   idx_t const nfactors = mats[0]->J;
 
   /* find out which level in the tree this is */
-  idx_t outdepth = csf_mode_depth(mode, ct->dim_perm, nmodes);
+  idx_t const outdepth = csf_mode_to_depth(ct, mode);
 
   val_t * mvals[MAX_NMODES];
   val_t * buf[MAX_NMODES];
@@ -993,7 +993,7 @@ static void p_csf_mttkrp_internal(
 
   int const tid = splatt_omp_get_thread_num();
   for(idx_t m=0; m < nmodes; ++m) {
-    mvals[m] = mats[ct->dim_perm[m]]->vals;
+    mvals[m] = mats[csf_depth_to_mode(ct, m)]->vals;
     /* grab the next row of buf from thds */
     buf[m] = ((val_t *) thds[tid].scratch[2]) + (nfactors * m);
     memset(buf[m], 0, nfactors * sizeof(val_t));
@@ -1158,7 +1158,7 @@ static void p_intl_decide(
     double const * const opts)
 {
   idx_t const nmodes = tensor->nmodes;
-  idx_t const depth = csf_mode_depth(mode, tensor->dim_perm, nmodes);
+  idx_t const depth = csf_mode_to_depth(tensor, mode);
 
   #pragma omp parallel
   {
@@ -1230,7 +1230,7 @@ void mttkrp_csf(
   splatt_csf_type which = opts[SPLATT_OPTION_CSF_ALLOC];
   switch(which) {
   case SPLATT_CSF_ONEMODE:
-    outdepth = csf_mode_depth(mode, tensors[0].dim_perm, nmodes);
+    outdepth = csf_mode_to_depth(&(tensors[0]), mode);
     if(outdepth == 0) {
       p_root_decide(tensors+0, mats, mode, thds, opts);
     } else if(outdepth == nmodes - 1) {
@@ -1242,11 +1242,11 @@ void mttkrp_csf(
 
   case SPLATT_CSF_TWOMODE:
     /* longest mode handled via second tensor's root */
-    if(mode == tensors[0].dim_perm[nmodes-1]) {
+    if(mode == csf_depth_to_mode(&(tensors[0]), nmodes-1)) {
       p_root_decide(tensors+1, mats, mode, thds, opts);
     /* root and internal modes are handled via first tensor */
     } else {
-      outdepth = csf_mode_depth(mode, tensors[0].dim_perm, nmodes);
+      outdepth = csf_mode_to_depth(&(tensors[0]), mode);
       if(outdepth == 0) {
         p_root_decide(tensors+0, mats, mode, thds, opts);
       } else {

--- a/src/stats.c
+++ b/src/stats.c
@@ -200,9 +200,9 @@ void stats_csf(
   for(idx_t m=1; m < ct->nmodes; ++m) {
     printf("x%"SPLATT_PF_IDX"", ct->dims[m]);
   }
-  printf(" (%"SPLATT_PF_IDX"", ct->dim_perm[0]);
+  printf(" (%"SPLATT_PF_IDX"", csf_depth_to_mode(ct, 0));
   for(idx_t m=1; m < ct->nmodes; ++m) {
-    printf("->%"SPLATT_PF_IDX"", ct->dim_perm[m]);
+    printf("->%"SPLATT_PF_IDX"", csf_depth_to_mode(ct, m));
   }
   printf(")\n");
   printf("ntiles: %"SPLATT_PF_IDX" tile dims: %"SPLATT_PF_IDX"", ct->ntiles,


### PR DESCRIPTION
`csf->dim_perm[]` is not always intuitive to use. This adds `csf_mode_to_depth()` and `csf_depth_to_mode()` for mapping modes to CSF levels (and vice versa). These should be much easier to use.