### PR TITLE
added option to disable OpenMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,27 @@ library, or configure SPLATT to also use 64-bit integers during configuration:
 
 Note that this may break usability of the SPLATT executable or API.
 
+Some Matlab versions have issues with linking to applications which use OpenMP
+(e.g., SPLATT) due to a limited amount of thread-local storage. This is a
+system limitation, not necessarily a software limitation. When calling SPLATT
+from Matlab, you may receive an error message:
 
-After compilation the MEX files will be found in the current directory. You can
-now call those functions directly:
+    dlopen: cannot load any more object with static TLS
+
+Two workarounds for this issue are:
+1. Ensure that your OpenMP library is loaded first when starting Matlab.  The
+most common OpenMP library is `libgomp.so.1`:
+
+    $ LD_PRELOAD=libgomp.so.1 matlab 
+
+2. Disable OpenMP (at the cost of losing multi-threaded execution):
+
+    $ ./configure --no-openmp
+
+
+
+After compilation, the MEX files will be found in the current directory. You
+can now call those functions directly:
 
     >> KT = splatt_cpd('mytensor.tns', 25);
 

--- a/cmake/openmp.cmake
+++ b/cmake/openmp.cmake
@@ -1,10 +1,16 @@
 
-find_package(OpenMP)
-if(${OPENMP_FOUND})
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+if(DEFINED DISABLE_OPENMP)
+  message("Disabling OpenMP. SPLATT will not be multi-threaded.")
+
+  set(SPLATT_NOWARN ${DISABLE_OPENMP})
 else()
-  message("OpenMP runtime not found! SPLATT will not be multithreaded.")
+  find_package(OpenMP)
+  if(${OPENMP_FOUND})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  else()
+    message("OpenMP runtime not found! SPLATT will not be multi-threaded.")
+  endif()
 endif()
 

--- a/configure
+++ b/configure
@@ -82,6 +82,12 @@ show_help() {
   echo "LIBRARY OPTIONS"
   echo "==============="
 
+  # OpenMP
+  echo "OpenMP"
+  echo "  --no-openmp"
+  echo "    Disable OpenMP support (i.e., disable multi-threading)."
+  echo ""
+
   # MPI
   echo "MPI"
   echo "  --with-mpi"
@@ -221,6 +227,10 @@ for i in "${@}"; do
       CONFIG_FLAGS="${CONFIG_FLAGS} -DDOWNLOAD_BLAS_LAPACK=TRUE"
     ;;
 
+    # OpenMP support
+    --no-openmp)
+      CONFIG_FLAGS="${CONFIG_FLAGS} -DDISABLE_OPENMP=1"
+    ;;
 
     # MPI support
     --with-mpi)


### PR DESCRIPTION
This gives the option to disable OpenMP support entirely, including linking to an OpenMP library. This is one workaround for the unfortunate Matlab issue #19, though going the `LD_PRELOAD` option is a much better solution I think.