### PR TITLE
stdout line buffering

### DIFF
--- a/src/cmds/splatt_bin.c
+++ b/src/cmds/splatt_bin.c
@@ -77,6 +77,8 @@ int main(
   int argc,
   char **argv)
 {
+  setvbuf(stdout, NULL, _IOLBF, 0);
+
   int rank = 0;
 #ifdef SPLATT_USE_MPI
   MPI_Init(&argc, &argv);


### PR DESCRIPTION
Forces stdout line buffering, which is on by default when running in a terminal, but not when piping to another program. When piping the default is to use block buffering, which in practice with SPLATT will not print its progress until the entire thing has completed. Compare with this test script which appears to hang with block buffering, but with line buffering will print output as it progresses normally as if SPLATT were running directly from the terminal:

```python
#!/usr/bin/python

from __future__ import print_function
import subprocess

cmd = ["./splatt", #change path as necessary
    "cpd",
    "med.tns", #change path as necessary
    "--nowrite",
    "--iters=5",
    "--rank=200"
    ]
    
proc = subprocess.Popen(cmd, stdout = subprocess.PIPE, universal_newlines = True)
for line in iter(proc.stdout.readline, ""):
    print(line, end = "")
proc.stdout.close()
proc.wait()
```