### PR TITLE
MTTKRP optimization + simplification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2016, Shaden Smith
+Copyright (c) 2014-2017, Shaden Smith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/splatt/api_kernels.h
+++ b/include/splatt/api_kernels.h
@@ -11,13 +11,24 @@
 #ifndef SPLATT_SPLATT_KERNELS_H
 #define SPLATT_SPLATT_KERNELS_H
 
+#include <stdbool.h>
+
+
+
 typedef struct
 {
   splatt_idx_t num_csf;
+  splatt_idx_t num_threads;
 
   splatt_idx_t mode_csf_map[SPLATT_MAX_NMODES];
 
+  splatt_idx_t * tile_partition[SPLATT_MAX_NMODES];
   splatt_idx_t * tree_partition[SPLATT_MAX_NMODES];
+
+  /* Mode privatization to avoid synchronization */
+  double reduction_time;
+  bool is_privatized[SPLATT_MAX_NMODES];
+  splatt_val_t * * privatize_buffer;
 } splatt_mttkrp_ws;
 
 

--- a/include/splatt/api_kernels.h
+++ b/include/splatt/api_kernels.h
@@ -3,13 +3,22 @@
 * @brief Functions for performing tensor kernels (e.g., norm, MTTKRP, TTMc).
 * @author Shaden Smith <shaden@cs.umn.edu>
 * @version 2.0.0
-* @date 2016-05-10
+* @date 2017-02-22
 */
 
 
 
 #ifndef SPLATT_SPLATT_KERNELS_H
 #define SPLATT_SPLATT_KERNELS_H
+
+typedef struct
+{
+  splatt_idx_t num_csf;
+
+  splatt_idx_t mode_csf_map[SPLATT_MAX_NMODES];
+
+  splatt_idx_t * tree_partition[SPLATT_MAX_NMODES];
+} splatt_mttkrp_ws;
 
 
 /*
@@ -47,6 +56,22 @@ int splatt_mttkrp(
     splatt_val_t ** matrices,
     splatt_val_t * const matout,
     double const * const options);
+
+
+splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
+    splatt_csf const * const tensors,
+    splatt_idx_t const ncolumns,
+    double const * const options);
+
+
+/**
+* @brief Free the memory allocated for an MTTKRP workspace.
+*
+* @param ws The workspace to free.
+*/
+void splatt_mttkrp_free_ws(
+    splatt_mttkrp_ws * const ws);
+
 
 /** @} */
 

--- a/include/splatt/types_config.h
+++ b/include/splatt/types_config.h
@@ -101,6 +101,7 @@ typedef enum
   SPLATT_OPTION_CSF_ALLOC,  /* How many (and which) tensors to allocate. */
   SPLATT_OPTION_TILE,       /* Use cache tiling during MTTKRP. */
   SPLATT_OPTION_TILELEVEL,  /* How many levels of the CSF are tiled? */
+  SPLATT_OPTION_PRIVTHRESH, /* Threshold for privatizing a mode. */
 
   SPLATT_OPTION_DECOMP,     /* Decomposition to use on distributed systems */
   SPLATT_OPTION_COMM,       /* Communication pattern to use */

--- a/src/bench.c
+++ b/src/bench.c
@@ -179,12 +179,16 @@ void bench_csf(
       printf("## THREADS %" SPLATT_PF_IDX "\n", nthreads);
     }
 
+    cpd_opts[SPLATT_OPTION_NTHREADS] = nthreads;
+
+    splatt_mttkrp_ws * ws = splatt_mttkrp_alloc_ws(cs, nfactors, cpd_opts);
+
     for(idx_t i=0; i < niters; ++i) {
       timer_fstart(&itertime);
       /* time each mode */
       for(idx_t m=0; m < tt->nmodes; ++m) {
         timer_fstart(&modetime);
-        mttkrp_csf(cs, mats, m, thds, cpd_opts);
+        mttkrp_csf(cs, mats, m, thds, ws, cpd_opts);
         timer_stop(&modetime);
         printf("  mode %" SPLATT_PF_IDX " %0.3fs\n", m+1, modetime.seconds);
         if(opts->write && t == nruns-1 && i == 0) {
@@ -198,6 +202,8 @@ void bench_csf(
       timer_stop(&itertime);
       printf("    its = %3"SPLATT_PF_IDX" (%0.3fs)\n", i+1, itertime.seconds);
     }
+
+    splatt_mttkrp_free_ws(ws);
 
     /* output load balance info */
     if(nruns > 1 || nthreads > 1) {

--- a/src/ccp/ccp.c
+++ b/src/ccp/ccp.c
@@ -1,5 +1,6 @@
 
 
+
 /******************************************************************************
  * INCLUDES
  *****************************************************************************/
@@ -117,12 +118,27 @@ idx_t partition_1d(
 
   nprobes = 0;
 
-  /* use recursive bisectioning with 0 tolerance to get exact solution */
-  idx_t bottleneck = p_eps_rb_partition_1d(weights, nitems, parts, nparts, 0);
+  idx_t bottleneck = 0;
 
-  /* apply partitioning that we found */
-  bool success = lprobe(weights, nitems, parts, nparts, bottleneck);
-  assert(success == true);
+  /* actual partitioning */
+  if(nitems > nparts) {
+    /* use recursive bisectioning with 0 tolerance to get exact solution */
+    bottleneck = p_eps_rb_partition_1d(weights, nitems, parts, nparts, 0);
+    /* apply partitioning that we found */
+    bool success = lprobe(weights, nitems, parts, nparts, bottleneck);
+    assert(success == true);
+
+  /* Do a trivial partitioning. Silly, but this happens when tensors have
+   * short modes. */
+  } else {
+    for(idx_t p=0; p < nitems; ++p) {
+      parts[p] = p;
+      bottleneck = SS_MAX(bottleneck, weights[p]);
+    }
+    for(idx_t p=nitems; p <= nparts; ++p) {
+      parts[p] = nitems;
+    }
+  }
 
   timer_stop(&timers[TIMER_PART]);
   return bottleneck;

--- a/src/ccp/ccp.c
+++ b/src/ccp/ccp.c
@@ -119,7 +119,7 @@ idx_t partition_1d(
   nprobes = 0;
 
   idx_t bottleneck = 0;
-
+  
   /* actual partitioning */
   if(nitems > nparts) {
     /* use recursive bisectioning with 0 tolerance to get exact solution */

--- a/src/cpd.c
+++ b/src/cpd.c
@@ -300,6 +300,9 @@ double cpd_als_iterate(
   /* used as buffer space */
   aTa[MAX_NMODES] = mat_alloc(nfactors, nfactors);
 
+  /* mttkrp workspace */
+  splatt_mttkrp_ws * mttkrp_ws = splatt_mttkrp_alloc_ws(tensors,nfactors,opts);
+
   /* Compute input tensor norm */
   double oldfit = 0;
   double fit = 0;
@@ -321,7 +324,7 @@ double cpd_als_iterate(
 
       /* M1 = X * (C o B) */
       timer_start(&timers[TIMER_MTTKRP]);
-      mttkrp_csf(tensors, mats, m, thds, opts);
+      mttkrp_csf(tensors, mats, m, thds, mttkrp_ws, opts);
       timer_stop(&timers[TIMER_MTTKRP]);
 
 #if 0
@@ -373,6 +376,7 @@ double cpd_als_iterate(
   cpd_post_process(nfactors, nmodes, mats, lambda, thds, nthreads, rinfo);
 
   /* CLEAN UP */
+  splatt_mttkrp_free_ws(mttkrp_ws);
   for(idx_t m=0; m < nmodes; ++m) {
     mat_free(aTa[m]);
   }

--- a/src/csf.c
+++ b/src/csf.c
@@ -816,7 +816,7 @@ idx_t * csf_partition_tiles_1d(
 
   #pragma omp parallel for schedule(static)
   for(idx_t i=0; i < ntiles; ++i) {
-    weights[i] = csf->pt->nfibs[nmodes-1];
+    weights[i] = csf->pt[i].nfibs[nmodes-1];
   }
 
   partition_1d(weights, ntiles, parts, nparts);

--- a/src/csf.h
+++ b/src/csf.h
@@ -178,4 +178,54 @@ static inline idx_t csf_depth_to_mode(
 
 
 
+#define csf_partition_1d splatt_csf_partition_1d
+/**
+* @brief Split the root nodes of a CSF tensor into 'nparts' partitions.
+*
+* @param csf The CSF tensor to partition.
+* @param nparts The number of partitions.
+*
+* @return An array of length (nparts+1) specifying the starts of each part.
+*/
+idx_t * csf_partition_1d(
+    splatt_csf const * const csf,
+    idx_t const tile_id,
+    idx_t const nparts);
+
+
+#define csf_partition_tiles_1d splatt_csf_partition_tiles_1d
+/**
+* @brief Split the tiles of csf into 'nparts' partitions.
+*        NOTE: This does not account for any mode-ordering of the tiles, and
+*        instead treats them as a 1D resource.
+*
+* @param csf The tiled tensor to partition.
+* @param nparts The number of partitions to compute.
+*
+* @return An array of length (nparts+1) specifying the starts of each part.
+*/
+idx_t * csf_partition_tiles_1d(
+    splatt_csf const * const csf,
+    idx_t const nparts);
+
+
+#define csf_count_nnz splatt_csf_count_nnz
+/**
+* @brief Count the nonzeros below a given node in a CSF tensor.
+*
+* @param fptr The adjacency pointer of the CSF tensor.
+* @param nmodes The number of modes in the tensor.
+* @param depth The depth of the node
+* @param fiber The id of the node.
+*
+* @return The nonzeros below fptr[depth][fiber].
+*/
+idx_t csf_count_nnz(
+    idx_t * * fptr,
+    idx_t const nmodes,
+    idx_t depth,
+    idx_t const fiber);
+
+
+
 #endif

--- a/src/mpi/mpi_cpd.c
+++ b/src/mpi/mpi_cpd.c
@@ -681,6 +681,9 @@ double mpi_cpd_als_iterate(
   /* used as buffer space */
   aTa[MAX_NMODES] = mat_alloc(nfactors, nfactors);
 
+  /* mttkrp workspace */
+  splatt_mttkrp_ws * mttkrp_ws = splatt_mttkrp_alloc_ws(tensors,nfactors,opts);
+
   /* Compute input tensor norm */
   double oldfit = 0;
   double fit = 0;
@@ -704,7 +707,7 @@ double mpi_cpd_als_iterate(
 
       /* M1 = X * (C o B) */
       timer_start(&timers[TIMER_MTTKRP]);
-      mttkrp_csf(tensors, mats, m, thds, opts);
+      mttkrp_csf(tensors, mats, m, thds, mttkrp_ws, opts);
       timer_stop(&timers[TIMER_MTTKRP]);
 
       m1->I = globmats[m]->I;
@@ -782,6 +785,7 @@ double mpi_cpd_als_iterate(
   free(tmp);
 
   /* CLEAN UP */
+  splatt_mttkrp_free_ws(mttkrp_ws);
   for(idx_t m=0; m < nmodes; ++m) {
     mat_free(aTa[m]);
   }

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -136,8 +136,8 @@ static void p_schedule_tiles(
     for(idx_t m=0; m < MAX_NMODES; ++m) {
       mats_priv[m] = mats[m];
     }
-    /* each thread gets separate structure, but do a shallow copy of ptr */
-    mats_priv[MAX_NMODES] = splatt_malloc(sizeof(*mats_priv));
+    /* each thread gets separate structure, but do a shallow copy */
+    mats_priv[MAX_NMODES] = splatt_malloc(sizeof(**mats_priv));
     *(mats_priv[MAX_NMODES]) = *(mats[MAX_NMODES]);
 
     /* Give each thread its own private buffer and overwrite atomic

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -152,13 +152,16 @@ static void p_schedule_tiles(
       sp_timer_t reduction_timer;
       timer_fstart(&reduction_timer);
 
-      /* reduction */
       idx_t const num_threads = splatt_omp_get_num_threads();
+      idx_t const elem_per_thread = (nrows * ncols) / num_threads;
+      idx_t const start = tid * elem_per_thread;
+      idx_t const stop  = ((idx_t)tid == num_threads-1) ?
+         (nrows * ncols) : (tid + 1) * elem_per_thread;
+
+      /* reduction */
       for(idx_t t=0; t < num_threads; ++t){
         val_t const * const restrict thread_buf = ws->privatize_buffer[t];
-
-        #pragma omp for schedule(static) nowait
-        for(idx_t x=0; x < nrows * ncols; ++x) {
+        for(idx_t x=start; x < stop; ++x) {
           global_output[x] += thread_buf[x];
         }
       }

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -1776,7 +1776,7 @@ splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
 
   idx_t num_csf = 0;
 
-  idx_t const num_threads = splatt_omp_get_max_threads();
+  idx_t const num_threads = (idx_t) opts[SPLATT_OPTION_NTHREADS];
   ws->num_threads = num_threads;
 
   /* map each MTTKRP mode to a CSF tensor */

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -1261,6 +1261,9 @@ void mttkrp_csf(
   splatt_mttkrp_ws * const ws,
   double const * const opts)
 {
+  /* ensure we use as many threads as our partitioning supports */
+  splatt_omp_set_num_threads(ws->num_threads);
+
   if(pool == NULL) {
     pool = mutex_alloc();
   }
@@ -1269,8 +1272,6 @@ void mttkrp_csf(
   matrix_t * const M = mats[MAX_NMODES];
   M->I = tensors[0].dims[mode];
   memset(M->vals, 0, M->I * M->J * sizeof(val_t));
-
-  splatt_omp_set_num_threads((idx_t) opts[SPLATT_OPTION_NTHREADS]);
 
   idx_t const nmodes = tensors[0].nmodes;
 

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -1837,7 +1837,7 @@ splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
     if(ws->is_privatized[m]) {
       largest_priv_dim = SS_MAX(largest_priv_dim, tensors->dims[m]);
       if((int)opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
-        printf("PRIVATIZING-MODE: %lu\n", m+1);
+        printf("PRIVATIZING-MODE: %"SPLATT_PF_IDX"\n", m+1);
       }
     }
   }

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -1776,7 +1776,11 @@ splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
 
   idx_t num_csf = 0;
 
+#ifdef _OPENMP
   idx_t const num_threads = (idx_t) opts[SPLATT_OPTION_NTHREADS];
+#else
+  idx_t const num_threads = 1;
+#endif
   ws->num_threads = num_threads;
 
   /* map each MTTKRP mode to a CSF tensor */

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -75,7 +75,7 @@ static void p_schedule_tiles(
 
   /* Store this in case we privatize */
   val_t * restrict global_output = mats[MAX_NMODES]->vals;
-  
+
   #pragma omp parallel
   {
     int const tid = splatt_omp_get_thread_num();
@@ -1290,8 +1290,10 @@ void mttkrp_csf(
   /* print thread times, if requested */
   if((int)opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
     printf("MTTKRP mode %"SPLATT_PF_IDX": ", mode+1);
-    printf("  reduction-time: %0.3fs\n", ws->reduction_time);
     thd_time_stats(thds, splatt_omp_get_max_threads());
+    if(ws->is_privatized[mode]) {
+      printf("  reduction-time: %0.3fs\n", ws->reduction_time);
+    }
   }
   thd_reset(thds, splatt_omp_get_max_threads());
 }
@@ -1820,7 +1822,7 @@ splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
 
   /* allocate privatization buffer */
   idx_t largest_priv_dim = 0;
-  ws->privatize_buffer =  
+  ws->privatize_buffer =
       splatt_malloc(num_threads * sizeof(*(ws->privatize_buffer)));
   for(idx_t m=0; m < tensors->nmodes; ++m) {
     ws->is_privatized[m] = p_is_privatized(tensors, m, opts);
@@ -1835,6 +1837,17 @@ splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
   for(idx_t t=0; t < num_threads; ++t) {
     ws->privatize_buffer[t] = splatt_malloc(largest_priv_dim * ncolumns *
         sizeof(**(ws->privatize_buffer)));
+  }
+  if(largest_priv_dim > 0 &&
+        (int)opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
+
+    size_t bytes = num_threads * largest_priv_dim * ncolumns *
+        sizeof(**(ws->privatize_buffer));
+    char * bstr = bytes_str(bytes);
+
+    printf("PRIVATIZATION-BUF: %s\n", bstr);
+    printf("\n");
+    free(bstr);
   }
 
   return ws;

--- a/src/mttkrp.c
+++ b/src/mttkrp.c
@@ -15,138 +15,185 @@
 static mutex_pool * pool = NULL;
 
 
-/******************************************************************************
- * API FUNCTIONS
- *****************************************************************************/
-int splatt_mttkrp(
-    splatt_idx_t const mode,
-    splatt_idx_t const ncolumns,
-    splatt_csf const * const tensors,
-    splatt_val_t ** matrices,
-    splatt_val_t * const matout,
-    double const * const options)
-{
-  idx_t const nmodes = tensors->nmodes;
 
-  /* fill matrix pointers  */
-  matrix_t * mats[MAX_NMODES+1];
-  for(idx_t m=0; m < nmodes; ++m) {
-    mats[m] = (matrix_t *) splatt_malloc(sizeof(matrix_t));
-    mats[m]->I = tensors->dims[m];
-    mats[m]->J = ncolumns,
-    mats[m]->rowmajor = 1;
-    mats[m]->vals = matrices[m];
-  }
-  mats[MAX_NMODES] = (matrix_t *) splatt_malloc(sizeof(matrix_t));
-  mats[MAX_NMODES]->I = tensors->dims[mode];
-  mats[MAX_NMODES]->J = ncolumns;
-  mats[MAX_NMODES]->rowmajor = 1;
-  mats[MAX_NMODES]->vals = matout;
+/**
+* @brief Function pointer that performs MTTKRP on a tile of a CSF tree.
+*
+* @param ct The CSF tensor.
+* @param tile_id The tile to process.
+* @param mats The matrices.
+* @param mode The output mode.
+* @param thds Thread structures.
+* @param partition A partitioning of the slices in the tensor, to distribute
+*                  to threads. Use the thread ID to decide which slices to
+*                  process. This may be NULL, in that case simply process all
+*                  slices.
+*/
+typedef void (* csf_mttkrp_func)(
+    splatt_csf const * const ct,
+    idx_t const tile_id,
+    matrix_t ** mats,
+    idx_t const mode,
+    thd_info * const thds,
+    idx_t const * const partition);
 
-  /* Setup thread structures. + 64 bytes is to avoid false sharing. */
-  idx_t const nthreads = (idx_t) options[SPLATT_OPTION_NTHREADS];
-  splatt_omp_set_num_threads(nthreads);
-  thd_info * thds =  thd_init(nthreads, 3,
-    (nmodes * ncolumns * sizeof(val_t)) + 64,
-    0,
-    (nmodes * ncolumns * sizeof(val_t)) + 64);
-
-  splatt_mttkrp_ws * ws = splatt_mttkrp_alloc_ws(tensors, ncolumns, options);
-
-  /* do the MTTKRP */
-  mttkrp_csf(tensors, mats, mode, thds, ws, options);
-
-  splatt_mttkrp_free_ws(ws);
-
-  /* cleanup */
-  thd_free(thds, nthreads);
-  for(idx_t m=0; m < nmodes; ++m) {
-    free(mats[m]);
-  }
-  free(mats[MAX_NMODES]);
-
-  return SPLATT_SUCCESS;
-}
-
-
-splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
-    splatt_csf const * const tensors,
-    splatt_idx_t const ncolumns,
-    double const * const opts)
-{
-  splatt_mttkrp_ws * ws = splatt_malloc(sizeof(*ws));
-
-  idx_t num_csf = 0;
-
-  idx_t const num_threads = (idx_t) opts[SPLATT_OPTION_NTHREADS];
-
-  /* map each MTTKRP mode to a CSF tensor */
-  splatt_csf_type which_csf = (splatt_csf_type) opts[SPLATT_OPTION_CSF_ALLOC];
-  for(idx_t m=0; m < tensors->nmodes; ++m) {
-    switch(which_csf) {
-    case SPLATT_CSF_ONEMODE:
-      /* only one tensor, map is easy */
-      ws->mode_csf_map[m] = 0;
-      num_csf = 1;
-      break;
-
-    case SPLATT_CSF_TWOMODE:
-      /* last mode is mapped to second tensor */
-      ws->mode_csf_map[m] = 0;
-      if(csf_mode_to_depth(&(tensors[0]), m) == tensors->nmodes-1) {
-        ws->mode_csf_map[m] = 1;
-      }
-      num_csf = 2;
-      break;
-
-    case SPLATT_CSF_ALLMODE:
-      /* each mode has its own tensor, map is easy */
-      ws->mode_csf_map[m] = m;
-      num_csf = tensors->nmodes;
-      break;
-
-    /* XXX */
-    default:
-      fprintf(stderr, "SPLATT: CSF type '%d' not recognized.\n", which_csf);
-      abort();
-      break;
-    }
-  }
-
-  assert(num_csf > 0);
-  ws->num_csf = num_csf;
-
-  /* Now setup partition info for each CSF. */
-  for(idx_t c=0; c < num_csf; ++c) {
-    ws->tree_partition[c] = NULL;
-  }
-  for(idx_t c=0; c < num_csf; ++c) {
-    splatt_csf const * const csf = &(tensors[c]);
-    if(tensors[c].ntiles > 1) {
-      ws->tree_partition[c] = csf_partition_tiles_1d(csf, num_threads);
-    } else {
-      ws->tree_partition[c] = csf_partition_1d(csf, 0, num_threads);
-    }
-  }
-
-  return ws;
-}
-
-
-void splatt_mttkrp_free_ws(
-    splatt_mttkrp_ws * const ws)
-{
-  for(idx_t c=0; c < ws->num_csf; ++c) {
-    splatt_free(ws->tree_partition[c]);
-  }
-  splatt_free(ws);
-}
 
 
 
 /******************************************************************************
  * PRIVATE FUNCTIONS
  *****************************************************************************/
+
+
+
+/**
+* @brief Map MTTKRP functions onto a (possibly tiled) CSF tensor. This function
+*        will handle any scheduling required with a partially tiled tensor.
+*
+* @param tensors An array of CSF representations. tensors[csf_id] is processed.
+* @param csf_id Which tensor are we processing?
+* @param atomic_func An MTTKRP function which atomically updates the output.
+* @param nosync_func An MTTKRP function which does not atomically update.
+* @param mats The matrices, with the output stored in mats[MAX_NMODES].
+* @param mode Which mode of 'tensors' is the output (not CSF depth).
+* @param thds Thread structures.
+* @param ws MTTKRP workspace.
+*/
+static void p_schedule_tiles(
+    splatt_csf const * const tensors,
+    idx_t const csf_id,
+    csf_mttkrp_func atomic_func,
+    csf_mttkrp_func nosync_func,
+    matrix_t ** mats,
+    idx_t const mode,
+    thd_info * const thds,
+    splatt_mttkrp_ws * const ws)
+{
+  splatt_csf const * const csf = &(tensors[csf_id]);
+  idx_t const nmodes = csf->nmodes;
+  idx_t const depth = nmodes - 1;
+
+  /* Store this in case we privatize */
+  val_t * restrict global_output = mats[MAX_NMODES]->vals;
+  
+  #pragma omp parallel
+  {
+    int const tid = splatt_omp_get_thread_num();
+    timer_start(&thds[tid].ttime);
+    idx_t const * const tile_partition = ws->tile_partition[csf_id];
+    idx_t const * const tree_partition = ws->tree_partition[csf_id];
+
+    idx_t const nrows = mats[mode]->I;
+    idx_t const ncols = mats[mode]->J;
+
+    /* Give each thread its own private buffer and overwrite atomic
+     * function. */
+    if(ws->is_privatized[mode]) {
+      mats[MAX_NMODES]->vals = ws->privatize_buffer[tid];
+      memset(ws->privatize_buffer[tid], 0,
+          nrows * ncols * sizeof(**(ws->privatize_buffer)));
+
+      /*
+       * Don't use atomics if we privatized.
+       */
+      atomic_func = nosync_func;
+    }
+
+    /*
+     * Distribute tiles to threads in some fashion.
+     */
+    if(csf->ntiles > 1) {
+      /* mode is actually tiled -- avoid synchronization */
+      if(csf->tile_dims[mode] > 1) {
+        idx_t tile_id = 0;
+
+        /* foreach layer of tiles */
+        #pragma omp for schedule(dynamic, 1) nowait
+        for(idx_t t=0; t < csf->tile_dims[mode]; ++t) {
+          tile_id =
+              get_next_tileid(TILE_BEGIN, csf->tile_dims, nmodes, mode, t);
+          while(tile_id != TILE_END) {
+            nosync_func(csf, tile_id, mats, mode, thds, tree_partition);
+            tile_id =
+              get_next_tileid(tile_id, csf->tile_dims, nmodes, mode, t);
+          }
+        }
+
+      /* tiled, but not this mode. Atomics are still necessary. */
+      } else {
+        for(idx_t tile_id = tile_partition[tid];
+                  tile_id < tile_partition[tid+1]; ++tile_id) {
+          atomic_func(csf, tile_id, mats, mode, thds, tree_partition);
+        }
+      }
+
+    /* untiled, parallelize within kernel */
+    } else {
+      atomic_func(csf, 0, mats, mode, thds, tree_partition);
+    }
+    timer_stop(&thds[tid].ttime);
+
+
+    /*
+     * If we used privatization, perform a reduction.
+     */
+    if(ws->is_privatized[mode]) {
+      /* Ensure everyone has completed their local MTTKRP. */
+      #pragma omp barrier
+
+      sp_timer_t reduction_timer;
+      timer_fstart(&reduction_timer);
+
+      /* reduction */
+      idx_t const num_threads = splatt_omp_get_num_threads();
+      for(idx_t t=0; t < num_threads; ++t){
+        val_t const * const restrict thread_buf = ws->privatize_buffer[t];
+
+        #pragma omp for schedule(static) nowait
+        for(idx_t x=0; x < nrows * ncols; ++x) {
+          global_output[x] += thread_buf[x];
+        }
+      }
+
+      timer_stop(&reduction_timer);
+      #pragma omp master
+      {
+        /* restore pointer */
+        mats[MAX_NMODES]->vals = global_output;
+        ws->reduction_time = reduction_timer.seconds;
+      }
+    } /* if privatized */
+  } /* end omp parallel */
+}
+
+
+/**
+* @brief Should a certain mode should be privatized to avoid locks?
+*
+* @param csf The tensor (just used for dimensions).
+* @param mode The mode we are processing.
+* @param opts Options, storing the # threads and the threshold.
+*
+* @return true, if we should privatize.
+*/
+static bool p_is_privatized(
+    splatt_csf const * const csf,
+    idx_t const mode,
+    double const * const opts)
+{
+  idx_t const length = csf->dims[mode];
+  idx_t const nthreads = (idx_t) opts[SPLATT_OPTION_NTHREADS];
+  double const thresh = opts[SPLATT_OPTION_PRIVTHRESH];
+
+  /* don't bother if it is not multithreaded. */
+  if(nthreads == 1) {
+    return false;
+  }
+
+  return (double)(length * nthreads) <= (thresh * (double)csf->nnz);
+}
+
+
 
 static inline void p_add_hada_clear(
   val_t * const restrict out,
@@ -298,7 +345,7 @@ static inline void p_propagate_up(
 }
 
 
-static void p_csf_mttkrp_root_tiled3(
+static void p_csf_mttkrp_root_nolock3(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -375,7 +422,7 @@ static void p_csf_mttkrp_root_tiled3(
 }
 
 
-static void p_csf_mttkrp_root3(
+static void p_csf_mttkrp_root3_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -453,7 +500,7 @@ static void p_csf_mttkrp_root3(
 }
 
 
-static void p_csf_mttkrp_internal3(
+static void p_csf_mttkrp_intl3_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -519,7 +566,7 @@ static void p_csf_mttkrp_internal3(
 }
 
 
-static void p_csf_mttkrp_leaf3(
+static void p_csf_mttkrp_leaf3_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -577,7 +624,7 @@ static void p_csf_mttkrp_leaf3(
 }
 
 
-static void p_csf_mttkrp_root_tiled(
+static void p_csf_mttkrp_root_nolock(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -595,7 +642,7 @@ static void p_csf_mttkrp_root_tiled(
   }
 
   if(nmodes == 3) {
-    p_csf_mttkrp_root_tiled3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_root_nolock3(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -645,7 +692,7 @@ static void p_csf_mttkrp_root_tiled(
 
 
 
-static void p_csf_mttkrp_root(
+static void p_csf_mttkrp_root_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -663,7 +710,7 @@ static void p_csf_mttkrp_root(
   }
 
   if(nmodes == 3) {
-    p_csf_mttkrp_root3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_root3_locked(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -702,14 +749,16 @@ static void p_csf_mttkrp_root(
 
     val_t * const restrict orow = ovals + (fid * nfactors);
     val_t const * const restrict obuf = buf[0];
+    mutex_set_lock(pool, fid);
     for(idx_t f=0; f < nfactors; ++f) {
       orow[f] += obuf[f];
     }
+    mutex_unset_lock(pool, fid);
   } /* end foreach outer slice */
 }
 
 
-static void p_csf_mttkrp_leaf_tiled3(
+static void p_csf_mttkrp_leaf_nolock3(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -767,7 +816,7 @@ static void p_csf_mttkrp_leaf_tiled3(
 
 
 
-static void p_csf_mttkrp_leaf_tiled(
+static void p_csf_mttkrp_leaf_nolock(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -782,7 +831,7 @@ static void p_csf_mttkrp_leaf_tiled(
     return;
   }
   if(nmodes == 3) {
-    p_csf_mttkrp_leaf_tiled3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_leaf_nolock3(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -853,7 +902,7 @@ static void p_csf_mttkrp_leaf_tiled(
 }
 
 
-static void p_csf_mttkrp_leaf(
+static void p_csf_mttkrp_leaf_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -869,7 +918,7 @@ static void p_csf_mttkrp_leaf(
     return;
   }
   if(nmodes == 3) {
-    p_csf_mttkrp_leaf3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_leaf3_locked(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -939,7 +988,7 @@ static void p_csf_mttkrp_leaf(
 }
 
 
-static void p_csf_mttkrp_internal_tiled3(
+static void p_csf_mttkrp_intl_nolock3(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -1003,7 +1052,7 @@ static void p_csf_mttkrp_internal_tiled3(
 }
 
 
-static void p_csf_mttkrp_internal_tiled(
+static void p_csf_mttkrp_intl_nolock(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -1019,7 +1068,7 @@ static void p_csf_mttkrp_internal_tiled(
     return;
   }
   if(nmodes == 3) {
-    p_csf_mttkrp_internal_tiled3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_intl_nolock3(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -1095,7 +1144,7 @@ static void p_csf_mttkrp_internal_tiled(
 }
 
 
-static void p_csf_mttkrp_internal(
+static void p_csf_mttkrp_intl_locked(
   splatt_csf const * const ct,
   idx_t const tile_id,
   matrix_t ** mats,
@@ -1111,7 +1160,7 @@ static void p_csf_mttkrp_internal(
     return;
   }
   if(nmodes == 3) {
-    p_csf_mttkrp_internal3(ct, tile_id, mats, mode, thds, partition);
+    p_csf_mttkrp_intl3_locked(ct, tile_id, mats, mode, thds, partition);
     return;
   }
 
@@ -1190,97 +1239,6 @@ static void p_csf_mttkrp_internal(
 
 
 
-/**
-* @brief Function pointer that performs MTTKRP on a tile of a CSF tree.
-*
-* @param ct The CSF tensor.
-* @param tile_id The tile to process.
-* @param mats The matrices.
-* @param mode The output mode.
-* @param thds Thread structures.
-* @param partition A partitioning of the slices in the tensor, to distribute
-*                  to threads. Use the thread ID to decide which slices to
-*                  process. This may be NULL, in that case simply process all
-*                  slices.
-*/
-typedef void (* csf_mttkrp_func)(
-    splatt_csf const * const ct,
-    idx_t const tile_id,
-    matrix_t ** mats,
-    idx_t const mode,
-    thd_info * const thds,
-    idx_t const * const partition);
-
-
-
-/**
-* @brief Map MTTKRP functions onto a (possibly tiled) CSF tensor. This function
-*        will handle any scheduling required with a partially tiled tensor.
-*
-* @param tensors An array of CSF representations. tensors[csf_id] is processed.
-* @param csf_id Which tensor are we processing?
-* @param atomic_func An MTTKRP function which atomically updates the output.
-* @param nosync_func An MTTKRP function which does not atomically update.
-* @param mats The matrices, with the output stored in mats[MAX_NMODES].
-* @param mode Which mode of 'tensors' is the output (not CSF depth).
-* @param thds Thread structures.
-* @param ws MTTKRP workspace.
-*/
-static void p_schedule_tiles(
-    splatt_csf const * const tensors,
-    idx_t const csf_id,
-    csf_mttkrp_func atomic_func,
-    csf_mttkrp_func nosync_func,
-    matrix_t ** mats,
-    idx_t const mode,
-    thd_info * const thds,
-    splatt_mttkrp_ws * const ws)
-{
-  splatt_csf const * const csf = &(tensors[csf_id]);
-  idx_t const nmodes = csf->nmodes;
-  idx_t const depth = nmodes - 1;
-
-  #pragma omp parallel
-  {
-    int const tid = splatt_omp_get_thread_num();
-    timer_start(&thds[tid].ttime);
-    idx_t const * const partition = ws->tree_partition[csf_id];
-
-    /* distribute tiles to threads */
-    if(csf->ntiles > 1) {
-      /* mode is actually tiled -- avoid synchronization */
-      if(csf->tile_dims[mode] > 1) {
-        idx_t tile_id = 0;
-
-        /* foreach layer of tiles */
-        #pragma omp for schedule(dynamic, 1) nowait
-        for(idx_t t=0; t < csf->tile_dims[mode]; ++t) {
-          tile_id = get_next_tileid(TILE_BEGIN, csf->tile_dims, nmodes, mode, t);
-          while(tile_id != TILE_END) {
-            nosync_func(csf, tile_id, mats, mode, thds, NULL);
-            tile_id = get_next_tileid(tile_id, csf->tile_dims, nmodes, mode, t);
-          }
-        }
-
-      /* tiled, but not this mode. Atomics are still necessary. */
-      } else {
-        for(idx_t tile_id = partition[tid]; tile_id < partition[tid+1]; ++tile_id) {
-          atomic_func(csf, tile_id, mats, mode, thds, NULL);
-        }
-      }
-
-    /* untiled, parallelize within kernel */
-    } else {
-      atomic_func(csf, 0, mats, mode, thds, partition);
-    }
-
-    timer_stop(&thds[tid].ttime);
-  } /* end omp parallel */
-}
-
-
-
-
 /******************************************************************************
  * PUBLIC FUNCTIONS
  *****************************************************************************/
@@ -1314,21 +1272,25 @@ void mttkrp_csf(
   idx_t const outdepth = csf_mode_to_depth(&(tensors[which_csf]), mode);
   if(outdepth == 0) {
     /* root */
-    p_schedule_tiles(tensors, which_csf, p_csf_mttkrp_root, p_csf_mttkrp_root_tiled,
+    p_schedule_tiles(tensors, which_csf,
+        p_csf_mttkrp_root_locked, p_csf_mttkrp_root_nolock,
         mats, mode, thds, ws);
   } else if(outdepth == nmodes - 1) {
     /* leaf */
-    p_schedule_tiles(tensors, which_csf, p_csf_mttkrp_leaf, p_csf_mttkrp_leaf_tiled,
+    p_schedule_tiles(tensors, which_csf,
+        p_csf_mttkrp_leaf_locked, p_csf_mttkrp_leaf_nolock,
         mats, mode, thds, ws);
   } else {
     /* internal */
-    p_schedule_tiles(tensors, which_csf, p_csf_mttkrp_internal, p_csf_mttkrp_internal_tiled,
+    p_schedule_tiles(tensors, which_csf,
+        p_csf_mttkrp_intl_locked, p_csf_mttkrp_intl_nolock,
         mats, mode, thds, ws);
   }
 
   /* print thread times, if requested */
-  if(opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
+  if((int)opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
     printf("MTTKRP mode %"SPLATT_PF_IDX": ", mode+1);
+    printf("  reduction-time: %0.3fs\n", ws->reduction_time);
     thd_time_stats(thds, splatt_omp_get_max_threads());
   }
   thd_reset(thds, splatt_omp_get_max_threads());
@@ -1737,5 +1699,162 @@ void mttkrp_stream(
 
   free(accum);
 }
+
+
+/******************************************************************************
+ * API FUNCTIONS
+ *****************************************************************************/
+int splatt_mttkrp(
+    splatt_idx_t const mode,
+    splatt_idx_t const ncolumns,
+    splatt_csf const * const tensors,
+    splatt_val_t ** matrices,
+    splatt_val_t * const matout,
+    double const * const options)
+{
+  idx_t const nmodes = tensors->nmodes;
+
+  /* fill matrix pointers  */
+  matrix_t * mats[MAX_NMODES+1];
+  for(idx_t m=0; m < nmodes; ++m) {
+    mats[m] = (matrix_t *) splatt_malloc(sizeof(matrix_t));
+    mats[m]->I = tensors->dims[m];
+    mats[m]->J = ncolumns,
+    mats[m]->rowmajor = 1;
+    mats[m]->vals = matrices[m];
+  }
+  mats[MAX_NMODES] = (matrix_t *) splatt_malloc(sizeof(matrix_t));
+  mats[MAX_NMODES]->I = tensors->dims[mode];
+  mats[MAX_NMODES]->J = ncolumns;
+  mats[MAX_NMODES]->rowmajor = 1;
+  mats[MAX_NMODES]->vals = matout;
+
+  /* Setup thread structures. + 64 bytes is to avoid false sharing. */
+  idx_t const nthreads = (idx_t) options[SPLATT_OPTION_NTHREADS];
+  splatt_omp_set_num_threads(nthreads);
+  thd_info * thds =  thd_init(nthreads, 3,
+    (nmodes * ncolumns * sizeof(val_t)) + 64,
+    0,
+    (nmodes * ncolumns * sizeof(val_t)) + 64);
+
+  splatt_mttkrp_ws * ws = splatt_mttkrp_alloc_ws(tensors, ncolumns, options);
+
+  /* do the MTTKRP */
+  mttkrp_csf(tensors, mats, mode, thds, ws, options);
+
+  splatt_mttkrp_free_ws(ws);
+
+  /* cleanup */
+  thd_free(thds, nthreads);
+  for(idx_t m=0; m < nmodes; ++m) {
+    free(mats[m]);
+  }
+  free(mats[MAX_NMODES]);
+
+  return SPLATT_SUCCESS;
+}
+
+
+splatt_mttkrp_ws * splatt_mttkrp_alloc_ws(
+    splatt_csf const * const tensors,
+    splatt_idx_t const ncolumns,
+    double const * const opts)
+{
+  splatt_mttkrp_ws * ws = splatt_malloc(sizeof(*ws));
+
+  idx_t num_csf = 0;
+
+  idx_t const num_threads = (idx_t) opts[SPLATT_OPTION_NTHREADS];
+  ws->num_threads = num_threads;
+
+  /* map each MTTKRP mode to a CSF tensor */
+  splatt_csf_type which_csf = (splatt_csf_type) opts[SPLATT_OPTION_CSF_ALLOC];
+  for(idx_t m=0; m < tensors->nmodes; ++m) {
+    switch(which_csf) {
+    case SPLATT_CSF_ONEMODE:
+      /* only one tensor, map is easy */
+      ws->mode_csf_map[m] = 0;
+      num_csf = 1;
+      break;
+
+    case SPLATT_CSF_TWOMODE:
+      /* last mode is mapped to second tensor */
+      ws->mode_csf_map[m] = 0;
+      if(csf_mode_to_depth(&(tensors[0]), m) == tensors->nmodes-1) {
+        ws->mode_csf_map[m] = 1;
+      }
+      num_csf = 2;
+      break;
+
+    case SPLATT_CSF_ALLMODE:
+      /* each mode has its own tensor, map is easy */
+      ws->mode_csf_map[m] = m;
+      num_csf = tensors->nmodes;
+      break;
+
+    /* XXX */
+    default:
+      fprintf(stderr, "SPLATT: CSF type '%d' not recognized.\n", which_csf);
+      abort();
+      break;
+    }
+  }
+
+  assert(num_csf > 0);
+  ws->num_csf = num_csf;
+
+  /* Now setup partition info for each CSF. */
+  for(idx_t c=0; c < num_csf; ++c) {
+    ws->tile_partition[c] = NULL;
+    ws->tree_partition[c] = NULL;
+  }
+  for(idx_t c=0; c < num_csf; ++c) {
+    splatt_csf const * const csf = &(tensors[c]);
+    if(tensors[c].ntiles > 1) {
+      ws->tile_partition[c] = csf_partition_tiles_1d(csf, num_threads);
+    } else {
+      ws->tree_partition[c] = csf_partition_1d(csf, 0, num_threads);
+    }
+  }
+
+
+  /* allocate privatization buffer */
+  idx_t largest_priv_dim = 0;
+  ws->privatize_buffer =  
+      splatt_malloc(num_threads * sizeof(*(ws->privatize_buffer)));
+  for(idx_t m=0; m < tensors->nmodes; ++m) {
+    ws->is_privatized[m] = p_is_privatized(tensors, m, opts);
+
+    if(ws->is_privatized[m]) {
+      largest_priv_dim = SS_MAX(largest_priv_dim, tensors->dims[m]);
+      if((int)opts[SPLATT_OPTION_VERBOSITY] == SPLATT_VERBOSITY_MAX) {
+        printf("PRIVATIZING-MODE: %lu\n", m+1);
+      }
+    }
+  }
+  for(idx_t t=0; t < num_threads; ++t) {
+    ws->privatize_buffer[t] = splatt_malloc(largest_priv_dim * ncolumns *
+        sizeof(**(ws->privatize_buffer)));
+  }
+
+  return ws;
+}
+
+
+void splatt_mttkrp_free_ws(
+    splatt_mttkrp_ws * const ws)
+{
+  for(idx_t t=0; t < ws->num_threads; ++t) {
+    splatt_free(ws->privatize_buffer[t]);
+  }
+  splatt_free(ws->privatize_buffer);
+
+  for(idx_t c=0; c < ws->num_csf; ++c) {
+    splatt_free(ws->tile_partition[c]);
+    splatt_free(ws->tree_partition[c]);
+  }
+  splatt_free(ws);
+}
+
 
 

--- a/src/mttkrp.h
+++ b/src/mttkrp.h
@@ -29,6 +29,7 @@
 * @param mats The output and input matrices.
 * @param mode Which mode we are computing for.
 * @param thds Thread structures. TODO: make this easier to allocate.
+* @param ws MTTKRP workspace.
 * @param opts SPLATT options. This uses SPLATT_OPTION_CSF_ALLOC.
 */
 void mttkrp_csf(
@@ -36,6 +37,7 @@ void mttkrp_csf(
   matrix_t ** mats,
   idx_t const mode,
   thd_info * const thds,
+  splatt_mttkrp_ws * const ws,
   double const * const opts);
 
 

--- a/src/opts.c
+++ b/src/opts.c
@@ -23,6 +23,8 @@ double * splatt_default_opts(void)
   opts[SPLATT_OPTION_CSF_ALLOC] = SPLATT_CSF_TWOMODE;
   opts[SPLATT_OPTION_TILE]      = SPLATT_NOTILE;
 
+  opts[SPLATT_OPTION_PRIVTHRESH] = 0.01;
+
   /* Tile one level by default. */
   opts[SPLATT_OPTION_TILELEVEL] = 1;
 

--- a/src/opts.c
+++ b/src/opts.c
@@ -23,7 +23,7 @@ double * splatt_default_opts(void)
   opts[SPLATT_OPTION_CSF_ALLOC] = SPLATT_CSF_TWOMODE;
   opts[SPLATT_OPTION_TILE]      = SPLATT_NOTILE;
 
-  opts[SPLATT_OPTION_PRIVTHRESH] = 0.01;
+  opts[SPLATT_OPTION_PRIVTHRESH] = 0.02;
 
   /* Tile one level by default. */
   opts[SPLATT_OPTION_TILELEVEL] = 1;

--- a/src/thd_info.c
+++ b/src/thd_info.c
@@ -183,9 +183,29 @@ void thd_times(
   idx_t const nthreads)
 {
   for(idx_t t=0; t < nthreads; ++t) {
-    printf("  thd: %"SPLATT_PF_IDX" %0.3fs\n", t, thds[t].ttime.seconds);
+    printf("  thread: %"SPLATT_PF_IDX" %0.3fs\n", t, thds[t].ttime.seconds);
   }
 }
+
+
+void thd_time_stats(
+  thd_info * thds,
+  idx_t const nthreads)
+{
+  double max_time = 0.;
+  double avg_time = 0.;
+  for(idx_t t=0; t < nthreads; ++t) {
+    avg_time += thds[t].ttime.seconds;
+    max_time = SS_MAX(max_time, thds[t].ttime.seconds);
+  }
+  avg_time /= nthreads;
+
+  double const imbal = (max_time - avg_time) / max_time;
+  printf("  avg: %0.3fs max: %0.3fs (%0.3f%% imbalance)\n",
+      avg_time, max_time, 100. * imbal);
+}
+
+
 
 void thd_reset(
   thd_info * thds,

--- a/src/thd_info.c
+++ b/src/thd_info.c
@@ -201,7 +201,7 @@ void thd_time_stats(
   avg_time /= nthreads;
 
   double const imbal = (max_time - avg_time) / max_time;
-  printf("  avg: %0.3fs max: %0.3fs (%0.3f%% imbalance)\n",
+  printf("  avg: %0.3fs max: %0.3fs (%0.1f%% imbalance)\n",
       avg_time, max_time, 100. * imbal);
 }
 

--- a/src/thd_info.h
+++ b/src/thd_info.h
@@ -117,12 +117,24 @@ void thd_reduce(
 
 #define thd_times splatt_thd_times
 /**
-* @brief Output a summary to STDOUT of all thread timers.
+* @brief Output a list of all thread timers.
 *
 * @param thds The array on thd_info structs.
 * @param nthreads The number of timers to print.
 */
 void thd_times(
+  thd_info * thds,
+  idx_t const nthreads);
+
+
+#define thd_time_stats splatt_thd_time_stats
+/**
+* @brief Output a summary to STDOUT of thread timers.
+*
+* @param thds The array on thd_info structs.
+* @param nthreads The number of timers to print.
+*/
+void thd_time_stats(
   thd_info * thds,
   idx_t const nthreads);
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -122,9 +122,13 @@ static inline double monotonic_seconds()
   static mach_timebase_info_data_t info;
   static double seconds_per_unit;
   if(seconds_per_unit == 0) {
-    mach_timebase_info(&info);
-    seconds_per_unit = (info.numer / info.denom) / 1e9;
+    #pragma omp critical
+    {
+      mach_timebase_info(&info);
+      seconds_per_unit = (info.numer / info.denom) / 1e9;
+    }
   }
+
   return seconds_per_unit * mach_absolute_time();
 #else
   /* Linux systems */

--- a/tests/mttkrp_test.c
+++ b/tests/mttkrp_test.c
@@ -54,7 +54,7 @@ static void p_csf_mttkrp(
 
     /* add 64 bytes to avoid false sharing */
     thd_info * thds = thd_init(nthreads, 3,
-      (nfactors * nfactors * sizeof(val_t)) + 64,
+      (tt->nmodes * nfactors * sizeof(val_t)) + 64,
       0,
       (tt->nmodes * nfactors * sizeof(val_t)) + 64);
 
@@ -70,8 +70,10 @@ static void p_csf_mttkrp(
       mats[i][MAX_NMODES] = gold[i];
       gold[i] = tmp;
 
-      /* compute splatt */
-      mttkrp_csf(cs, mats[i], m, thds, opts);
+      /* compute MTTKRP */
+      splatt_mttkrp_ws * ws = splatt_mttkrp_alloc_ws(cs, nfactors, opts);
+      mttkrp_csf(cs, mats[i], m, thds, ws, opts);
+      splatt_mttkrp_free_ws(ws);
 
       __compare_mats(mats[i][MAX_NMODES], gold[i]);
     }


### PR DESCRIPTION
This incorporates many (but not all) of the optimizations presented in our IPDPS'17 paper. What's missing are the AVX-512 intrinsics and accounting hub slices (both to come!).

The CSF selection code is greatly simplified, and tiling now allows us to parallelize even when modes are very short. Privatization during MTTKRP also allows us to avoid synchronization overheads when
modes are short.